### PR TITLE
Update UEFormat to support generic import helper function similar to UTextAssetFactory

### DIFF
--- a/Unreal/UEFormat/Source/UEFormat/Public/Factories/UEModelFactory.h
+++ b/Unreal/UEFormat/Source/UEFormat/Public/Factories/UEModelFactory.h
@@ -17,6 +17,8 @@ class UEFORMAT_API UEModelFactory : public UFactory
 	bool bImport;
 	bool bImportAll;
 
+	static UObject* Import(const FString& Filename, const FString& PackagePath, const FName Name, const EObjectFlags Flags, TMap<FString, FString> MaterialNameToPathMap);
+
 	virtual UObject* FactoryCreateFile(UClass* Class, UObject* Parent, FName Name, EObjectFlags Flags, const FString& Filename, const TCHAR* Params, FFeedbackContext* Warn, bool& bOutOperationCanceled) override;
 
 	UStaticMesh* CreateStaticMesh(UEModelReader& Data, UObject* Parent, EObjectFlags Flags);


### PR DESCRIPTION
- Removed UI popup for skeleton assignment on SkeletalMesh import. This is only used for Animations and also compatible skeletons/retargeters should be used if not using included skeleton.
- Added auto saving packages for static mesh, skeletal mesh and skeleton