### PR TITLE
Fix scale setting not having on effect on model imports

### DIFF
--- a/Blender/io_scene_ueformat/op/panels.py
+++ b/Blender/io_scene_ueformat/op/panels.py
@@ -25,7 +25,7 @@ class UEFORMAT_PT_Panel(Panel):  # noqa: N801
     def draw_general_options(obj: Panel | Operator, settings: UFSettings) -> None:
         box = obj.layout.box()
         box.label(text="General", icon="SETTINGS")
-        box.row().prop(settings, "scale")
+        box.row().prop(settings, "scale_factor")
 
     @staticmethod
     def draw_model_options(

--- a/Blender/io_scene_ueformat/op/settings.py
+++ b/Blender/io_scene_ueformat/op/settings.py
@@ -5,7 +5,7 @@ from bpy.types import PropertyGroup
 
 
 class UFSettings(PropertyGroup):
-    scale: FloatProperty(name="Scale", default=0.01, min=0.01)
+    scale_factor: FloatProperty(name="Scale", default=0.01, min=0.01)
     bone_length: FloatProperty(name="Bone Length", default=4.0, min=0.1)
     reorient_bones: BoolProperty(name="Reorient Bones", default=False)
     import_lods: BoolProperty(name="Import Levels of Detail", default=False)


### PR DESCRIPTION
Property was (presumably) incorrectly named `scale` instead of `scale_factor`, preventing it from overriding that value in UEFormatOptions, which functionally locked import scale to 0.01 for meter scale workflows. This commit makes the scale setting actually work so that it could be set to 1.0 for centimeter scale workflows, or anything else.