### PR TITLE
Add bl_description to prevent crash

### DIFF
--- a/io_scene_ueformat/op/import_helpers.py
+++ b/io_scene_ueformat/op/import_helpers.py
@@ -37,6 +37,7 @@ class UFImportBase(Operator, ImportHelper, Generic[T]):
 class UFImportUEModel(UFImportBase):
     bl_idname = "uf.import_uemodel"
     bl_label = "Import Model"
+    bl_description = "Import Model"
 
     filename_ext = ".uemodel"
     filter_glob: StringProperty(default="*.uemodel", options={"HIDDEN"}, maxlen=255)
@@ -55,6 +56,7 @@ class UFImportUEModel(UFImportBase):
 class UFImportUEAnim(UFImportBase):
     bl_idname = "uf.import_ueanim"
     bl_label = "Import Animation"
+    bl_description = "Import Animation"
 
     filename_ext = ".ueanim"
     filter_glob: StringProperty(default="*.ueanim", options={"HIDDEN"}, maxlen=255)
@@ -72,6 +74,7 @@ class UFImportUEAnim(UFImportBase):
 class UFImportUEPose(UFImportBase):
     bl_idname = "uf.import_uepose"
     bl_label = "Import Pose"
+    bl_description = "Import Pose"
 
     filename_ext = ".uepose"
     filter_glob: StringProperty(default="*.uepose", options={"HIDDEN"}, maxlen=255)


### PR DESCRIPTION
Some versions of Blender (at least 4.4.0) will crash when hovering over the import button due to a bug in blender: https://projects.blender.org/blender/blender/issues/136420