### PR TITLE
Update `__annotation__` in `settings.py`

### DIFF
--- a/io_scene_ueformat/op/settings.py
+++ b/io_scene_ueformat/op/settings.py
@@ -1,3 +1,5 @@
+from annotationlib import get_annotations
+
 from bpy.props import BoolProperty, FloatProperty, IntProperty
 from bpy.types import PropertyGroup
 from typing import Any
@@ -20,7 +22,7 @@ class UFSettings(PropertyGroup):
     def get_props(self) -> dict[str, Any]:
         props = {}
 
-        for key in self.__annotations__.keys():
+        for key in get_annotations(UFSettings).keys():
             props[key] = getattr(self, key)
 
         return props


### PR DESCRIPTION
In Python 3.14, which Blender 5.0.1 uses, annotations had been reworked such that `__annotations__` is not directly accessible. This is used in `op/settings.py`, and causes the following error when used in Blender 5.0.1:

> Python: Traceback (most recent call last):
 File "..../io_scene_ueformat/op/import_helpers.py", line 27, in execute
    options = self.options_class.from_settings(context.scene.uf_settings)
  File "..../io_scene_ueformat/options.py", line 21, in from_settings
    k: v for k, v in settings.get_props().items()
                     ~~~~~~~~~~~~~~~~~~^^
  File "..../io_scene_ueformat/op/settings.py", line 23, in get_props
    for key in self.\_\_annotations\_\_.keys():
               ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'UFSettings' object has no attribute '\_\_annotations\_\_'. Did you mean: '\_\_annotate_func\_\_'?

My fix is to use `annotationlib.get_annotations` instead of `__annotations__`.