### PR TITLE
switch to getattr() for annotations

### DIFF
--- a/plugins/blender/io_scene_ueformat/op/settings.py
+++ b/plugins/blender/io_scene_ueformat/op/settings.py
@@ -20,7 +20,7 @@ class UFSettings(PropertyGroup):
     def get_props(self) -> dict[str, Any]:
         props = {}
 
-        for key in self.__annotations__.keys():
+        for key in getattr(type(self), '__annotations__', {}).keys():
             props[key] = getattr(self, key)
 
         return props


### PR DESCRIPTION
Fixes a crash in newer python/blender versions while being retro-compatible.
Fixes the bug causing
```
Python: Traceback (most recent call last):
File "..../io_scene_ueformat/op/import_helpers.py", line 27, in execute
options = self.options_class.from_settings(context.scene.uf_settings)
File "..../io_scene_ueformat/options.py", line 21, in from_settings
k: v for k, v in settings.get_props().items()
~~~~~~~~~~~~~~~~~~^^
File "..../io_scene_ueformat/op/settings.py", line 23, in get_props
for key in self.__annotations__.keys():
^^^^^^^^^^^^^^^^^^^^
AttributeError: 'UFSettings' object has no attribute '__annotations__'. Did you mean: '__annotate_func__'?
```